### PR TITLE
fixing eatom cache

### DIFF
--- a/hexlite/clingobackend.py
+++ b/hexlite/clingobackend.py
@@ -221,10 +221,10 @@ class CachedEAtomEvaluator(EAtomEvaluator):
   def evaluate(self, holder, inputtuple, predicateinputatoms):
     # this is handled by defaultdict
     storage = self.cache[holder.name][inputtuple]
-    if predicateinputatoms not in storage:
-      storage[predicateinputatoms] = EAtomEvaluator.evaluate(
+    if frozenset(x for x in predicateinputatoms if x.isTrue()) not in storage:
+      storage[frozenset(x for x in predicateinputatoms if x.isTrue())] = EAtomEvaluator.evaluate(
         self, holder, inputtuple, predicateinputatoms)
-    return storage[predicateinputatoms]
+    return storage[frozenset(x for x in predicateinputatoms if x.isTrue())]
 
 class GringoContext:
   class ExternalAtomCall:

--- a/hexlite/clingobackend.py
+++ b/hexlite/clingobackend.py
@@ -221,10 +221,12 @@ class CachedEAtomEvaluator(EAtomEvaluator):
   def evaluate(self, holder, inputtuple, predicateinputatoms):
     # this is handled by defaultdict
     storage = self.cache[holder.name][inputtuple]
-    if frozenset(x for x in predicateinputatoms if x.isTrue()) not in storage:
-      storage[frozenset(x for x in predicateinputatoms if x.isTrue())] = EAtomEvaluator.evaluate(
+    positiveinputatoms = frozenset(x for x in predicateinputatoms if x.isTrue())
+    assert(all(x.isTrue() or x.isFalse() for x in predicateinputatoms))
+    if positiveinputatoms not in storage:
+      storage[positiveinputatoms] = EAtomEvaluator.evaluate(
         self, holder, inputtuple, predicateinputatoms)
-    return storage[frozenset(x for x in predicateinputatoms if x.isTrue())]
+    return storage[positiveinputatoms]
 
 class GringoContext:
   class ExternalAtomCall:


### PR DESCRIPTION
The storage dictionary for the eatom evaluation cache is not indexed by interpretations, but by a set containing all input atoms. Because of this, the eatoms are not evaluated again when the interpretation changes. This can be seen with the following program:

```
d(0). d(1).
a(b) ; n_a(b).
num(X) :- &num[a](X), d(X).
```

And the corresponding external atom implementation:
```
import dlvhex

def num(a):
	n = 0
	for x in dlvhex.getInputAtoms():
		if x.tuple()[0] == a and x.isTrue():
			n += 1
	
	dlvhex.output((n, ))
	
def register():
	dlvhex.addAtom("num", (dlvhex.PREDICATE, ), 1)
```

These are the correct answer sets:
```
{a(b),d(0),d(1),num(1)}
{n_a(b),d(0),d(1),num(0)}
```

These are the returned answer sets:
```
{a(b),d(0),d(1),num(1)}
{n_a(b),d(0),d(1),num(1)}
```

I propose only using true input atoms to index the storage dict to fix this 6814b9765cdffcb435619fb11f409a34d03a3d58.